### PR TITLE
Amanda Patch for Premium Rendering

### DIFF
--- a/client/src/components/Billing.js
+++ b/client/src/components/Billing.js
@@ -16,6 +16,7 @@ class Billing extends Component {
               <Elements>
                 <CheckoutForm
                   id={this.props.userInfo.user._id}
+                  // !! Experimental patch !!
                   premiumUser={
                     this.props.premiumUser ||
                     this.props.userInfo.user.premiumUser

--- a/client/src/components/Billing.js
+++ b/client/src/components/Billing.js
@@ -16,7 +16,10 @@ class Billing extends Component {
               <Elements>
                 <CheckoutForm
                   id={this.props.userInfo.user._id}
-                  premiumUser={this.props.userInfo.user.premiumUser}
+                  premiumUser={
+                    this.props.premiumUser ||
+                    this.props.userInfo.user.premiumUser
+                  }
                   processPayment={this.props.processPayment}
                 />
               </Elements>
@@ -35,6 +38,7 @@ const mapStateToProps = state => {
   );
   return {
     userInfo: state.auth.currentUser,
+    premiumUser: state.user.premiumUser,
     msg: state.user.message
   };
 };

--- a/client/src/components/Progress/Progress.js
+++ b/client/src/components/Progress/Progress.js
@@ -22,7 +22,7 @@ class Progress extends Component {
 
     return (
       <div className="outer-container">
-        {this.props.userInfo.user.premiumUser ? (
+        {this.props.premiumUser || this.props.userInfo.user.premiumUser ? (
           <div className="container">
             <ProgressTracker />
             <ProgressForm />
@@ -48,6 +48,7 @@ class Progress extends Component {
 const mapStateToProps = state => {
   return {
     progressRecords: state.progress.progressRecords,
+    premiumUser: state.user.premiumUser,
     userInfo: state.auth.currentUser
   };
 };

--- a/client/src/components/Progress/Progress.js
+++ b/client/src/components/Progress/Progress.js
@@ -22,6 +22,7 @@ class Progress extends Component {
 
     return (
       <div className="outer-container">
+        {/* Experimental Patch - Premium User Toggle */}
         {this.props.premiumUser || this.props.userInfo.user.premiumUser ? (
           <div className="container">
             <ProgressTracker />

--- a/client/src/components/Settings.js
+++ b/client/src/components/Settings.js
@@ -17,7 +17,6 @@ class Settings extends Component {
   };
 
   handleEmailSubmit = event => {
-    event.preventDefault();
     this.props.changeEmail({
       username: this.props.userInfo.user.username,
       newEmail: this.state.email

--- a/client/src/reducers/user.js
+++ b/client/src/reducers/user.js
@@ -1,7 +1,8 @@
 import * as Actions from "../actions/actionDefinitions";
 
 const initialState = {
-  message: ""
+  message: "",
+  premiumUser: false
 };
 
 export default (state = initialState, action) => {
@@ -74,7 +75,8 @@ export default (state = initialState, action) => {
     case Actions.PAYMENT_SUCCESS:
       return {
         ...state,
-        message: "Payment was successful"
+        message: "Payment was successful",
+        premiumUser: true
       };
     case Actions.PAYMENT_FAILURE:
       return {


### PR DESCRIPTION
# Description

Please include a summary of the change and a link to which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Faked persistence of Premium Status after charging. Locally the user will be set to a premium user, then upon refresh the store will pull from the logged in user rather than the local.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally, charged a user then switched pages many times to ensure rendering properly, then refreshed to ensure "persistence"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
